### PR TITLE
Fixes zsh: no matches found: HEAD^

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -2,6 +2,7 @@
 setopt correct                                                  # Auto correct mistakes
 setopt extendedglob                                             # Extended globbing. Allows using regular expressions with *
 setopt nocaseglob                                               # Case insensitive globbing
+unsetopt nomatch						# Passes the command as is instead of reporting pattern matching failure see Chrysostomus/manjaro-zsh-config#14
 setopt rcexpandparam                                            # Array expension with parameters
 setopt nocheckjobs                                              # Don't warn about running processes when exiting
 setopt numericglobsort                                          # Sort filenames numerically when it makes sense


### PR DESCRIPTION
Disable nomatch so that invalid pattern matching are passed as is as the underlying command instead of triggering a zsh error.

closes #14