### PR TITLE
Avoid broken output of less

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -71,7 +71,7 @@ export LESS_TERMCAP_se=$'\E[0m'
 export LESS_TERMCAP_so=$'\E[01;47;34m'
 export LESS_TERMCAP_ue=$'\E[0m'
 export LESS_TERMCAP_us=$'\E[01;36m'
-export LESS=-r
+export LESS=-R
 
 
 ## Plugins section: Enable fish style features


### PR DESCRIPTION
After a fresh manjaro install, I was getting output of `less` with missing lines and strange behavior. It took me some time to figure out that this was causing it. It was not a really fancy use of `less` either.

As per the `less` manpage:

       -r or --raw-control-chars
              ... Warning: when the -r option is used, less cannot keep track of the actual appearance of the  screen  (since  this
              depends on how the screen responds to each type of control character).  Thus, various display problems may result,
              such as long lines being split in the wrong place.

       -R or --RAW-CONTROL-CHARS
              Like -r, but only ANSI "color" escape sequences are output in "raw" form.  Unlike  -r,  the  screen appearance  is
              maintained correctly in most cases. ...

I'm using `-R` for years and it works great, so IMHO `-R` is the more sensible option, especially for a config coming as default with an OS.