### PR TITLE
[changes] Removed unneeded stuff; change omz > mzc

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -97,9 +97,8 @@ fi
 # usage: title short_tab_title [long_window_title]
 #
 # See: http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
-# Fully supports screen, iterm, and probably most modern xterm and rxvt
+# Fully supports screen and probably most modern xterm and rxvt
 # (In screen, only short_tab_title is used)
-# Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
   emulate -L zsh
   setopt prompt_subst
@@ -111,7 +110,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*)
+    xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*)
       print -Pn "\e]2;${2:q}\a" # set window name
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;
@@ -134,13 +133,13 @@ ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m:%~"
 
 # Runs before showing the prompt
-function omz_termsupport_precmd {
+function mzc_termsupport_precmd {
   [[ "${DISABLE_AUTO_TITLE:-}" == true ]] && return
   title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 }
 
 # Runs before executing the command
-function omz_termsupport_preexec {
+function mzc_termsupport_preexec {
   [[ "${DISABLE_AUTO_TITLE:-}" == true ]] && return
 
   emulate -L zsh
@@ -190,5 +189,5 @@ function omz_termsupport_preexec {
 }
 
 autoload -U add-zsh-hook
-add-zsh-hook precmd omz_termsupport_precmd
-add-zsh-hook preexec omz_termsupport_preexec
+add-zsh-hook precmd mzc_termsupport_precmd
+add-zsh-hook preexec mzc_termsupport_preexec


### PR DESCRIPTION
Small changes:
- Removed note for Apple Terminal
- Removed iterm support in note section
- Removed cygwin
- change variable omz to mzc (mzc = manjaro-zsh-config)