### PR TITLE
Zhistory fix: https://forum.manjaro.org/t/zsh-shell-history-getting-cleared-automatically-while-using-gnome-terminal-zhistory/48416

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -20,6 +20,10 @@ zstyle ':completion:*' cache-path ~/.zsh/cache
 HISTFILE=~/.zhistory
 HISTSIZE=1000
 SAVEHIST=500
+
+#Get all entrys from history File
+alias history="history 0"
+
 #export EDITOR=/usr/bin/nano
 #export VISUAL=/usr/bin/nano
 WORDCHARS=${WORDCHARS//\/[&.;]}                                 # Don't consider certain characters part of the word


### PR DESCRIPTION
Not the best fix, only created a alias 