### PR TITLE
respect USE_POWERLINE once again

### DIFF
--- a/manjaro-zsh-prompt
+++ b/manjaro-zsh-prompt
@@ -1,28 +1,31 @@
 () {
   emulate -L zsh
 
+  source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme
+  source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
+
   # Determine terminal capabilities.
   {
-    zmodload zsh/langinfo zsh/terminfo &&
-      [[ $langinfo[CODESET] == (utf|UTF)(-|)8 && $TERM != (dumb|linux) ]] &&
-      (( terminfo[colors] >= 256 ))
+    if ! zmodload zsh/langinfo zsh/terminfo ||
+       [[ $langinfo[CODESET] != (utf|UTF)(-|)8 || $TERM == (dumb|linux) ]] ||
+       (( terminfo[colors] < 256 )); then
+      # Don't use the powerline config. It won't work on this terminal.
+      local USE_POWERLINE=false
+      # Define alias `x` if our parent process is `login`.
+      local parent
+      if { parent=$(</proc/$PPID/comm) } && [[ ${parent:t} == login ]]; then
+        alias x='startx ~/.xinitrc'
+      fi
+    fi
   } 2>/dev/null
 
-  if (( $? )); then
+  if [[ $USE_POWERLINE == false ]]; then
     # Use 8 colors and ASCII.
     source /usr/share/zsh/p10k-portable.zsh
     ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=black,bold'
-    local parent
-    if { parent=$(</proc/$PPID/comm) } 2>/dev/null && [[ ${parent:t} == login ]]; then
-      # Define `x` if our parent process is `login`.
-      alias x='startx ~/.xinitrc'
-    fi
   else
     # Use 256 colors and UNICODE.
     source /usr/share/zsh/p10k.zsh
     ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=244'
   fi
-
-  source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme
-  source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
 }


### PR DESCRIPTION
[bfbafe9c1c99](https://github.com/Chrysostomus/manjaro-zsh-config/commit/b6990f0b78d7610c84f494395fc7889f9f8a1e34) (#30) introduced a bug: the code stopped respecting `USE_POWERLINE=false` (sorry about that!). This PR fixes it.