### PR TITLE
Several bug fixes and improvements for `/root/.zshrc`

### DIFF
--- a/rootzshrc
+++ b/rootzshrc
@@ -5,9 +5,10 @@ setopt rcexpandparam                                            # Array expensio
 setopt nocheckjobs                                              # Don't warn about running processes when exiting
 setopt numericglobsort                                          # Sort filenames numerically when it makes sense
 setopt nobeep                                                   # No beep
-setopt appendhistory                                            # Immediately append history instead of overwriting
+setopt incappendhistory                                         # Immediately append history instead of overwriting
 setopt histignorealldups                                        # If a new command is a duplicate, remove the older one
-setopt autocd                                                   # if only directory path is entered, cd there.
+setopt autocd                                                   # If only directory path is entered, cd there
+setopt interactivecomments                                      # Allow comments even in interactive shells
 
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'       # Case insensitive tab completion
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"         # Colored completion (different colors for dirs/files/etc)
@@ -17,21 +18,27 @@ HISTSIZE=1000
 SAVEHIST=500
 export EDITOR=/usr/bin/nano
 export VISUAL=/usr/bin/nano
-WORDCHARS=${WORDCHARS//\/[&.;]}                                 # Don't consider certain characters part of the word
+WORDCHARS=${WORDCHARS//[\/&.;]}                                 # Don't consider certain characters part of the word
 
 alias cp="cp -i"
 ## Keybindings section
 bindkey -e
-bindkey '^[[7~' beginning-of-line                               # Home key
-bindkey '^[[8~' end-of-line                                     # End key
+bindkey '^[[H'  beginning-of-line                               # Home key (xterm)
+bindkey '^[[OH' beginning-of-line                               # Home key (smkx mode)
+bindkey '^[[1~' beginning-of-line                               # Home key (screen & tmux)
+bindkey '^[[7~' beginning-of-line                               # Home key (urxvt)
+bindkey '^[[F'  end-of-line                                     # End key (xterm)
+bindkey '^[[OF' end-of-line                                     # End key (smkx mode)
+bindkey '^[[4~' end-of-line                                     # End key (screen & tmux)
+bindkey '^[[8~' end-of-line                                     # End key (urxvt)
 bindkey '^[[2~' overwrite-mode                                  # Insert key
 bindkey '^[[3~' delete-char                                     # Delete key
 bindkey '^[[C'  forward-char                                    # Right key
 bindkey '^[[D'  backward-char                                   # Left key
 bindkey '^[[5~' history-beginning-search-backward               # Page up key
 bindkey '^[[6~' history-beginning-search-forward                # Page down key
-bindkey '^[[A'  up-line-or-history                  # Up key
-bindkey '^[[B'  down-line-or-history                # Down key
+bindkey '^[[A'  up-line-or-history                              # Up key
+bindkey '^[[B'  down-line-or-history                            # Down key
 # Navigate words with ctrl+arrow keys
 bindkey '^[Oc' forward-word                                     #
 bindkey '^[Od' backward-word                                    #
@@ -41,16 +48,16 @@ bindkey '^H' backward-kill-word                                 # delete previou
 bindkey '^[[Z' undo                                             # Shift+tab undo last action
 
 ## Theming section  
-autoload -U compinit colors zcalc
+autoload -Uz compinit colors zcalc
 compinit
 colors
 
 # enable substitution for prompt
 setopt prompt_subst
 # bash style prompt 
-PROMPT="[%n@%m %1~]# %{$reset_color%"
+PROMPT='[%n@%m %1~]%# '
 # Right prompt with exit status of previous command if not successful
- RPROMPT="%{$fg[red]%} %(?..[%?])" 
+RPROMPT='%(?..%F{red}[%?]%f)'
 # Color man pages
 export LESS_TERMCAP_mb=$'\E[01;32m'
 export LESS_TERMCAP_md=$'\E[01;32m'


### PR DESCRIPTION
While debugging #30 I noticed that root's zsh leaks red foreground and doesn't understand comments:

![image](https://user-images.githubusercontent.com/1282067/141799121-4b2fa828-d79d-4f5c-bee8-8f1fb87120c1.png)

Here the first 3 red lines is the command I've typed. `export LESS=-r` is the output of `tail`. Note that both of these are red. And then there is "bad pattern" error due to a comment in my command.

Also, my Home and End keys didn't work. I've fixed these issues and a few more that I noticed in the same file.

- Don't leave red foreground on at the start of every command. This causes the command line to be red. It also randomly and  inconsistently colors output of commands red.
- Remove an unnecessary space from right prompt.
- Use the newer syntax for colors: `'%F{red}this is red%f'`.
- Show '%' instead of '#' in prompt if the user is not privileged. This matches bash prompt (although bash uses '$' instead of '%') and standard convention.
- Correctly autoload functions even if `KSH_AUTOLOAD` is set.
- Make Home and End keys work in all mainstream terminals.
- Remove '/', '&', '.' and ';' from `WORDCHARS` as it seems to have been intended. Previously, only '/' and '&' were removed.
- Enable `INTERACTIVE_COMMENTS` so that zsh doesn't barf when users copy-paste commands with comments in them.
- Replace `APPEND_HISTORY` with `INC_APPEND_HISTORY`. The latter is significantly less likely to result in the loss of history and it matches the existing comment.
