### PR TITLE
Update p10k.zsh

### DIFF
--- a/p10k.zsh
+++ b/p10k.zsh
@@ -391,7 +391,7 @@
       # Otherwise show the first 12 … the last 12.
       # Tip: To always show local branch name in full without truncation, delete the next line.
       (( $#branch > 32 )) && branch[13,-13]="…"  # <-- this line
-      res+="${clean}${(g::)POWERLEVEL9K_VCS_BRANCH_ICON}${branch//\%/%%}"
+      res+="${clean}${(g::)POWERLEVEL9K_VCS_BRANCH_ICON}${branch//\%/%%}  "
     fi
 
     if [[ -n $VCS_STATUS_TAG


### PR DESCRIPTION
The git branch name always had the last 2 letters truncated by the triangle style. I added two spaces to the variable in that line, so that the full branch name is readable. Regular "non-gitted" folders aren't affected.