### PR TITLE
Update p10k.zsh again

### DIFF
--- a/p10k.zsh
+++ b/p10k.zsh
@@ -391,7 +391,7 @@
       # Otherwise show the first 12 … the last 12.
       # Tip: To always show local branch name in full without truncation, delete the next line.
       (( $#branch > 32 )) && branch[13,-13]="…"  # <-- this line
-      res+="${clean}${(g::)POWERLEVEL9K_VCS_BRANCH_ICON}${branch//\%/%%}  "
+      res+="${clean}${(g::)POWERLEVEL9K_VCS_BRANCH_ICON}${branch//\%/%%}"
     fi
 
     if [[ -n $VCS_STATUS_TAG
@@ -453,7 +453,7 @@
     # in this case.
     (( VCS_STATUS_HAS_UNSTAGED == -1 )) && res+=" ${modified}─"
 
-    typeset -g my_git_format=$res
+    typeset -g my_git_format="$res  "
   }
   functions -M my_git_formatter 2>/dev/null
 


### PR DESCRIPTION
Sorry for sending another PR, but after I actually used git, I noticed the other Git status numbers wouldn't render properly, so I figured out a better place for my blank spaces. Now it seems like everything renders properly.