### PR TITLE
Revert #36 and #37

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -54,10 +54,10 @@ bindkey '^[[1;5C' forward-word                                  #
 bindkey '^H' backward-kill-word                                 # delete previous word with ctrl+backspace
 bindkey '^[[Z' undo                                             # Shift+tab undo last action
 
-## Alias section 
-alias cp='f(){fo=${1:--i}; shift; cp $fo $*};f'                                           # Confirm before overwriting something
-alias df='f(){if test $# -eq 0;then opts=(-h);else opts=("$@");fi; df "$opts[@]"};f'      # Human-readable sizes
-alias free='f(){if test $# -eq 0;then opts=(-m);else opts=("$@");fi; free "$opts[@]"};f'  # Show sizes in MB
+## Alias section
+alias cp="cp -i"                                                # Confirm before overwriting something
+alias df='df -h'                                                # Human-readable sizes
+alias free='free -m'                                            # Show sizes in MB
 alias gitu='git add . && git commit && git push'
 
 # Theming section  


### PR DESCRIPTION
The `shift` in the alias for `cp` emits an error message when `cp` is used without any arguments:
```
~ > cp        
f:shift: shift count must be <= $#
cp: missing file operand
Try 'cp --help' for more information.
```
Furthermore, the aliases don't do what they say they do. The comment of `Confirm before overwriting something` does not apply, because the `-i` is only added if no other arguments are provided. This becomes clear when we try the function that `cp` is aliased to in the shell, but with calls to `echo` showing the argument array:
```zsh
cp_alias(){echo initial: $1; fo=${1:--i}; echo modified: $fo; shift; cp $fo $*}
```
When called with zero arguments, we do get `-i`:
```
~ > cp_alias                                                                       
initial:
modified: -i
cp_alias:shift: shift count must be <= $#
...
```
When called with any arguments at all, we no longer get `-i`:
```
~ > cp_alias x
initial: x
modified: x
...
```
I set up a couple of test files to try out the current `cp` alias, and it definitely doesn't add `-i`:
```
~ > touch x
~ > touch y
~ > cp x y
~ > # It should have asked if I want to overwrite!
```
Compare this to when we use `cp -i`:
```
~ > cp -i x y
cp: overwrite 'y'?
```
I understand that the original edits were intended to allow the arguments to be overridden, but the current aliases are incorrect and even give error messages. If users want to bypass the aliases, they can just use the built-in backslash feature: running `\cp` instead of `cp` will cause the alias to be ignored.
```
~ > alias cp="cp -i"
# With a backslash, we don't get a prompt
~ > \cp x y
# Without a backslash, we do get one
~ > cp x y   
cp: overwrite 'y'?
```