### PR TITLE
fix: use character classes instead of ranges in matcher-list pattern

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -12,7 +12,7 @@ setopt autocd                                                   # if only direct
 setopt inc_append_history                                       # save commands are added to the history immediately, otherwise only when shell exits.
 setopt histignorespace                                          # Don't save commands that start with space
 
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'       # Case insensitive tab completion
+zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' # Case insensitive tab completion
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"         # Colored completion (different colors for dirs/files/etc)
 zstyle ':completion:*' rehash true                              # automatically find new executables in path 
 # Speed up completions

--- a/rootzshrc
+++ b/rootzshrc
@@ -10,7 +10,7 @@ setopt histignorealldups                                        # If a new comma
 setopt autocd                                                   # If only directory path is entered, cd there
 setopt interactivecomments                                      # Allow comments even in interactive shells
 
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'       # Case insensitive tab completion
+zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' # Case insensitive tab completion
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"         # Colored completion (different colors for dirs/files/etc)
 zstyle ':completion:*' rehash true                              # automatically find new executables in path 
 HISTFILE=~/.zhistory


### PR DESCRIPTION
Hi,
completion would insert a capital letter at the point of ambiguity, but further completion would then complete based on that inserted character missing the other "completion-direction"/files.

It's hard to describe so I'll show it:
`$` is my prompt, `>` is the completed prompt
(using `ls -d` so that the directory name will be listedin output)
```
$ ls -d /etc/nf*
/etc/nfs.conf  /etc/nfsmount.conf  /etc/nftables.conf  /etc/nftables.d
$ ls -d /etc/nf<tab>
> ls -d /etc/nfT
$ ls -d /etc/nfT<tab>
> ls -d /etc/nftables.
```

Changing from character ranges `{a-zA-Z}` to character classes `{[:lower:][:upper:]}` fixes that.

EDIT:
It seems related to https://github.com/ohmyzsh/ohmyzsh/issues/10972 and an issue of ZSH itself as mentioned there, but nevertheless this PR helps.