### PR TITLE
Add: zstyle menu select

### DIFF
--- a/manjaro-zsh-config
+++ b/manjaro-zsh-config
@@ -15,6 +15,7 @@ setopt histignorespace                                          # Don't save com
 zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' # Case insensitive tab completion
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"         # Colored completion (different colors for dirs/files/etc)
 zstyle ':completion:*' rehash true                              # automatically find new executables in path 
+zstyle ':completion:*' menu select                              # Highlight menu selection
 # Speed up completions
 zstyle ':completion:*' accept-exact '*(N)'
 zstyle ':completion:*' use-cache on


### PR DESCRIPTION
It would be nice that when you enter the menu of options, the current option is highlighted. The default config does not have this functionality. Which can be resolved by adding one line to the config.

This is what I am referring to:

![zstyleMenuSelect](https://github.com/Chrysostomus/manjaro-zsh-config/assets/107062289/ee19aded-7a5b-4f25-8b4d-1e451d0cac53)
