### PR TITLE
Make git section extra space an opt-in feature

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,9 @@
 # Use powerline
 USE_POWERLINE="true"
+# Has weird character width
+# Example:
+#    is not a diamond
+HAS_WIDECHARS="false"
 # Source manjaro-zsh-configuration
 if [[ -e /usr/share/zsh/manjaro-zsh-config ]]; then
   source /usr/share/zsh/manjaro-zsh-config

--- a/p10k.zsh
+++ b/p10k.zsh
@@ -453,7 +453,11 @@
     # in this case.
     (( VCS_STATUS_HAS_UNSTAGED == -1 )) && res+=" ${modified}─"
 
-    typeset -g my_git_format="$res  "
+    if [[ $HAS_WIDECHARS == true ]]; then
+      typeset -g my_git_format="$res  "
+    else
+      typeset -g my_git_format="$res"
+    fi
   }
   functions -M my_git_formatter 2>/dev/null
 


### PR DESCRIPTION
As I [mention in a previous PR](https://github.com/Chrysostomus/manjaro-zsh-config/pull/34#issuecomment-1472760668) https://github.com/Chrysostomus/manjaro-zsh-config/pull/34#issuecomment-1472760668, that configuration must be an opt-in config for whoever got this problem.

In neither of my computers using this configuration, I'm experiencing the issue stated in the PR. I'm using Manjaro Gnome, KDE, XFCE and Cinnamon configurations.

I truly believe this must the use of a not prepared font, or wrong setup in the [ambiguous width characters](https://help.gnome.org/users/gnome-terminal/stable/pref-profile-char-width.html.en).

It is really annoying to keep changing the code manually every time I update the package, as it will always lead to a weird looking misplacement of the last segment separator, like this

![image](https://github.com/Chrysostomus/manjaro-zsh-config/assets/30298743/adb0a83e-1718-4cb7-8d45-8b0f728d9d89)

Instead of the normal looking way

![image](https://github.com/Chrysostomus/manjaro-zsh-config/assets/30298743/40095ab3-4300-4d44-b4fd-003eac92cc09)

This PR includes an opt-in feature to add that extraspace via `.zshrc` like this:

```zsh
# Has weird character width
# Example:
#    is not a diamond
HAS_WIDECHARS="true"
```